### PR TITLE
fix/product-save-req-dto-type

### DIFF
--- a/src/main/java/site/moasis/moasisapi/product/dto/ProductReqDto.java
+++ b/src/main/java/site/moasis/moasisapi/product/dto/ProductReqDto.java
@@ -11,7 +11,7 @@ public class ProductReqDto {
     private String name;
     private Long price;
     private String details;
-    private String encodedFile;
+    private byte[] encodedFile;
     private String category;
     private int quantity;
     private String productNumber;

--- a/src/main/java/site/moasis/moasisapi/product/service/ProductService.java
+++ b/src/main/java/site/moasis/moasisapi/product/service/ProductService.java
@@ -2,10 +2,11 @@ package site.moasis.moasisapi.product.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import site.moasis.moasisapi.product.repository.ProductRepository;
 import site.moasis.moasisapi.product.dto.ProductReqDto;
 import site.moasis.moasisapi.product.entity.Product;
+import site.moasis.moasisapi.product.repository.ProductRepository;
 
+import java.util.Base64;
 import java.util.UUID;
 
 @Service
@@ -16,7 +17,8 @@ public class ProductService {
 
     public String createProduct(ProductReqDto productReqDto) {
         String productCode = UUID.randomUUID().toString();
-        String imageUrl = imageService.uploadFile(productReqDto.getEncodedFile());
+        String encodedFileBase64 = Base64.getEncoder().encodeToString(productReqDto.getEncodedFile());
+        String imageUrl = imageService.uploadFile(encodedFileBase64);
         Product product = Product.builder()
                 .name(productReqDto.getName())
                 .price(productReqDto.getPrice())


### PR DESCRIPTION
## #️⃣ PR과 관련된 내용(Notion Ticket)

## 📝 작업 내용
- post /product ReqDto 수정
- encodedFile 타입 String -> byte[] 수정
- Base64 encoder를 통해 byte array 인코딩 로직 추가

## 💬 리뷰 요구사항
다음과 같이 테스트를 진행하였습니다.
<img width="253" alt="image" src="https://github.com/moasis-team/moasis-api/assets/75880928/8412a071-3127-45ca-b401-8fc3d5c54551">
다음과 같이 구글 드라이브에 올라오는 것을 확인했습니다.
<img width="782" alt="image" src="https://github.com/moasis-team/moasis-api/assets/75880928/81c08b77-561a-49d3-9dac-158c7381e75e">


## 체크리스트
- [x] 빌드 실패 및 코드 오류가 없는지
- [x] 미리 정의 된 린트 룰에 위배되지 않는지
- [x] 로컬에서 개발자 검증을 완료하였는지

