### PR TITLE
feature/add-notifications-contoller-get-method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,4 @@
 postgres:
 	docker run --name moasis -p 5432:5432 -e POSTGRES_USER=root -e POSTGRES_PASSWORD=secret -e POSTGRES_DB=moasis -d postgres:14-alpine
+redis:
+	docker run --name moasis-redis -p 6379:6379 -d redis:alpine

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -28,8 +28,8 @@ repositories {
 dependencies {
     implementation project(':common')
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.cloud:spring-cloud-function-context'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/api/http-requests/notification.http
+++ b/api/http-requests/notification.http
@@ -1,0 +1,15 @@
+### get notifications
+GET http://localhost:8080/api/notifications?pageNumber=0&pageSize=10
+
+### read notifications
+POST http://localhost:8080/api/notifications/read
+Content-Type: application/json
+
+{
+  "notificationKeys": [
+    "{{notificationKey}}"
+  ]
+}
+
+### exist unread notifications
+GET http://localhost:8080/api/notifications/exist-unread

--- a/api/src/main/java/site/moasis/api/ApiApplication.java
+++ b/api/src/main/java/site/moasis/api/ApiApplication.java
@@ -18,7 +18,6 @@ import java.util.Map;
 @EnableJpaRepositories(basePackages = {"site.moasis.common.repository"})
 @EntityScan(basePackages = {"site.moasis.common.entity"})
 public class ApiApplication {
-
     public static void main(String[] args) {
         SpringApplication app = new SpringApplication(ApiApplication.class);
         Map<String, Object> defaultProperties = new HashMap<>();

--- a/api/src/main/java/site/moasis/api/controller/NotificationController.java
+++ b/api/src/main/java/site/moasis/api/controller/NotificationController.java
@@ -1,7 +1,6 @@
 package site.moasis.api.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import site.moasis.api.response.CommonResponse;
@@ -17,11 +16,11 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @GetMapping
-    public ResponseEntity<CommonResponse<Slice<GetNotificationListDTO>>> getNotificationList(
+    public ResponseEntity<CommonResponse<GetNotificationListDTO>> getNotificationList(
         @RequestParam("pageNumber") int pageNumber,
         @RequestParam("pageSize") int pageSize
     ) {
-        Slice<GetNotificationListDTO> response = notificationService.getNotificationList(pageNumber, pageSize);
+        GetNotificationListDTO response = notificationService.getNotificationList(pageNumber, pageSize);
         return CommonResponse.success(response, "활동 알림 조회에 성공했습니다.");
     }
 

--- a/api/src/main/java/site/moasis/api/controller/NotificationController.java
+++ b/api/src/main/java/site/moasis/api/controller/NotificationController.java
@@ -1,0 +1,41 @@
+package site.moasis.api.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import site.moasis.api.response.CommonResponse;
+import site.moasis.api.service.NotificationService;
+import site.moasis.common.dto.GetNotificationListDTO;
+import site.moasis.common.dto.SetNotificationListAsReadRequestDTO;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<CommonResponse<Slice<GetNotificationListDTO>>> getNotificationList(
+        @RequestParam("pageNumber") int pageNumber,
+        @RequestParam("pageSize") int pageSize
+    ) {
+        Slice<GetNotificationListDTO> response = notificationService.getNotificationList(pageNumber, pageSize);
+        return CommonResponse.success(response, "활동 알림 조회에 성공했습니다.");
+    }
+
+    @PostMapping("/read")
+    public ResponseEntity<CommonResponse<String[]>> setNotificationListAsRead(
+        @RequestBody SetNotificationListAsReadRequestDTO setNotificationListAsReadRequestDTO
+    ) {
+        String[] response = notificationService.setNotificationListAsRead(setNotificationListAsReadRequestDTO);
+        return CommonResponse.success(response, "OK");
+    }
+
+    @GetMapping("/exist-unread")
+    public ResponseEntity<CommonResponse<Boolean>> existUnReadNotification() {
+        boolean response = notificationService.existUnreadNotification();
+        return CommonResponse.success(response, "OK");
+    }
+}

--- a/api/src/main/java/site/moasis/api/controller/ProductController.java
+++ b/api/src/main/java/site/moasis/api/controller/ProductController.java
@@ -7,23 +7,33 @@ import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import site.moasis.api.response.CommonResponse;
+import site.moasis.api.service.NotificationService;
 import site.moasis.api.service.ProductService;
 import site.moasis.common.dto.CreateProductRequestDTO;
 import site.moasis.common.dto.GetProductResponseDTO;
 import site.moasis.common.dto.PatchProductRequestDTO;
 import site.moasis.common.dto.PatchProductResponseDTO;
+import site.moasis.common.entity.Product;
+import site.moasis.common.enums.NotificationType;
 
 @RestController
 @RequestMapping("/api/products")
 @RequiredArgsConstructor
 public class ProductController {
     private final ProductService productService;
+    private final NotificationService notificationService;
 
     @PostMapping()
     public ResponseEntity<CommonResponse<String>> createProduct(
         @Valid @RequestBody CreateProductRequestDTO createProductRequestDTO
     ) {
-        String response = productService.createProduct(createProductRequestDTO);
+        Product product = productService.createProduct(createProductRequestDTO);
+        String response = product.getProductCode();
+        notificationService.createNotification(
+            NotificationType.CREATE,
+            product,
+            product.getQuantity()
+        );
         return CommonResponse.success(response, "상품이 등록되었습니다.");
     }
 
@@ -50,13 +60,25 @@ public class ProductController {
         @PathVariable("productCode") String productCode,
         @Valid @RequestBody PatchProductRequestDTO patchProductRequestDTO
     ) {
-        PatchProductResponseDTO response = productService.updateProduct(productCode, patchProductRequestDTO);
+        Product product = productService.updateProduct(productCode, patchProductRequestDTO);
+        PatchProductResponseDTO response = PatchProductResponseDTO.of(product);
+        notificationService.createNotification(
+            NotificationType.UPDATE,
+            product,
+            0
+        );
         return CommonResponse.success(response, "상품이 수정되었습니다.");
     }
 
     @DeleteMapping("/{productCode}")
     public ResponseEntity<CommonResponse<String>> deleteProduct(@PathVariable("productCode") String productCode) {
-        String response = productService.deleteProduct(productCode);
+        Product product = productService.deleteProduct(productCode);
+        String response = product.getProductCode();
+        notificationService.createNotification(
+            NotificationType.DELETE,
+            product,
+            0
+        );
         return CommonResponse.success(response, "상품이 삭제되었습니다.");
     }
 }

--- a/api/src/main/java/site/moasis/api/factory/NotificationFactory.java
+++ b/api/src/main/java/site/moasis/api/factory/NotificationFactory.java
@@ -1,0 +1,35 @@
+package site.moasis.api.factory;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Component;
+import site.moasis.api.service.NotificationReadStatusKeyService;
+import site.moasis.common.dto.GetNotificationListDTO;
+import site.moasis.common.entity.Notification;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationFactory {
+    private final NotificationReadStatusKeyService notificationReadStatusKeyService;
+
+    public GetNotificationListDTO createGetNotificationListDTOFromSlice(Slice<Notification> notificationSlice) {
+        return GetNotificationListDTO.builder()
+            .slice(
+                notificationSlice.map(
+                    notification -> {
+                        boolean isRead = notificationReadStatusKeyService.getIsRead(notification.getKey());
+                        return GetNotificationListDTO.GetNotificationListInnerDTO.builder()
+                            .key(notification.getKey())
+                            .type(notification.getType())
+                            .productNumber(notification.getProductNumber())
+                            .productName(notification.getProductName())
+                            .remainingQuantity(notification.getRemainingQuantity())
+                            .changedAmount(notification.getChangedAmount())
+                            .isRead(isRead)
+                            .build();
+                    }
+                )
+            )
+            .build();
+    }
+}

--- a/api/src/main/java/site/moasis/api/service/NotificationReadStatusKeyService.java
+++ b/api/src/main/java/site/moasis/api/service/NotificationReadStatusKeyService.java
@@ -8,16 +8,11 @@ import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
-public class NotificationStatusKeyService {
+public class NotificationReadStatusKeyService {
     private final RedisTemplate<String, Boolean> redisTemplate;
 
-    public void setNotificationStatus(String notificationReadStatusKey, boolean isRead) {
-        redisTemplate.opsForValue().set(notificationReadStatusKey, isRead);
-    }
-
-    public String createNotificationReadStatusKey() {
-        Long sequence = redisTemplate.opsForValue().increment("notificationIsRead" + ":seq");
-        return "notificationIsRead" + ":" + sequence;
+    public void setNotificationReadStatus(String notificationId, boolean isRead) {
+        redisTemplate.opsForValue().set(notificationId, isRead);
     }
 
     public boolean existUnreadNotification() {
@@ -29,5 +24,15 @@ public class NotificationStatusKeyService {
             if (value != null) return true;
         }
         return false;
+    }
+
+    public void createNotificationReadStatus(String notificationKey) {
+        redisTemplate.opsForValue().set(notificationKey, Boolean.FALSE);
+    }
+
+    public boolean getIsRead(String notificationKey) {
+        Boolean isRead = redisTemplate.opsForValue().get(notificationKey);
+        if (isRead == null) return false;
+        return isRead;
     }
 }

--- a/api/src/main/java/site/moasis/api/service/NotificationService.java
+++ b/api/src/main/java/site/moasis/api/service/NotificationService.java
@@ -1,0 +1,66 @@
+package site.moasis.api.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.moasis.common.dto.GetNotificationListDTO;
+import site.moasis.common.dto.SetNotificationListAsReadRequestDTO;
+import site.moasis.common.entity.Notification;
+import site.moasis.common.entity.Product;
+import site.moasis.common.enums.NotificationType;
+import site.moasis.common.repository.NotificationRepository;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+    private final NotificationStatusKeyService notificationStatusKeyService;
+
+    public Slice<GetNotificationListDTO> getNotificationList(int pageNumber, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        Slice<Notification> response = notificationRepository.findAllByOrderByCreatedAtDesc(pageable);
+
+        return GetNotificationListDTO.fromSlice(response);
+    }
+
+    @Transactional
+    public String[] setNotificationListAsRead(SetNotificationListAsReadRequestDTO readNotificationRequestDTO) {
+        List<Notification> notificationList = Arrays.stream(readNotificationRequestDTO.getNotificationKeys()).map(notificationRepository::findByKey).toList();
+        if (notificationList.get(0) == null) return new String[0];
+
+        String[] notificationReadStatusKeyList = notificationList.stream().map(Notification::getNotificationReadStatusKey).toArray(String[]::new);
+        Arrays.stream(notificationReadStatusKeyList).forEach(key -> notificationStatusKeyService.setNotificationStatus(key, true));
+
+        return readNotificationRequestDTO.getNotificationKeys();
+    }
+
+    @Transactional
+    public void createNotification(NotificationType notificationType, Product product, int changedAmount) {
+        String notificationKey = UUID.randomUUID().toString();
+        String notificationReadStatusKey = notificationStatusKeyService.createNotificationReadStatusKey();
+
+        Notification notification = Notification.builder()
+            .key(notificationKey)
+            .productName(product.getName())
+            .productNumber(product.getProductNumber())
+            .type(notificationType)
+            .remainingQuantity(product.getQuantity())
+            .changedAmount(changedAmount)
+            .notificationReadStatusKey(notificationReadStatusKey)
+            .build();
+
+        notificationRepository.save(notification);
+    }
+
+    public boolean existUnreadNotification() {
+        return notificationStatusKeyService.existUnreadNotification();
+    }
+}

--- a/api/src/main/java/site/moasis/api/service/NotificationStatusKeyService.java
+++ b/api/src/main/java/site/moasis/api/service/NotificationStatusKeyService.java
@@ -1,0 +1,33 @@
+package site.moasis.api.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationStatusKeyService {
+    private final RedisTemplate<String, Boolean> redisTemplate;
+
+    public void setNotificationStatus(String notificationReadStatusKey, boolean isRead) {
+        redisTemplate.opsForValue().set(notificationReadStatusKey, isRead);
+    }
+
+    public String createNotificationReadStatusKey() {
+        Long sequence = redisTemplate.opsForValue().increment("notificationIsRead" + ":seq");
+        return "notificationIsRead" + ":" + sequence;
+    }
+
+    public boolean existUnreadNotification() {
+        Set<String> keys = redisTemplate.keys("*");
+        if (keys == null || keys.isEmpty()) return false;
+
+        for (String key : keys) {
+            Boolean value = redisTemplate.opsForValue().get(key);
+            if (value != null) return true;
+        }
+        return false;
+    }
+}

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -38,6 +38,7 @@ spring:
       - classpath:/application-google.yaml
       - classpath:/application-h2.yaml
       - classpath:/application-slack.yaml
+      - classpath:/application-redis.yaml
 
 springdoc:
   api-docs:

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -23,6 +23,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/common/src/main/java/site/moasis/common/configuration/RedisConfig.java
+++ b/common/src/main/java/site/moasis/common/configuration/RedisConfig.java
@@ -1,0 +1,39 @@
+package site.moasis.common.configuration;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+public class RedisConfig {
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name = "redisTemplate")
+    public RedisTemplate<String, Boolean> redisTemplate() {
+        RedisTemplate<String, Boolean> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/common/src/main/java/site/moasis/common/configuration/RedisConfig.java
+++ b/common/src/main/java/site/moasis/common/configuration/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @RequiredArgsConstructor
@@ -27,12 +28,12 @@ public class RedisConfig {
         redisTemplate.setConnectionFactory(redisConnectionFactory());
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
 
-        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+        redisTemplate.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
 
         return redisTemplate;
     }

--- a/common/src/main/java/site/moasis/common/dto/GetNotificationListDTO.java
+++ b/common/src/main/java/site/moasis/common/dto/GetNotificationListDTO.java
@@ -1,0 +1,30 @@
+package site.moasis.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+import site.moasis.common.entity.Notification;
+import site.moasis.common.enums.NotificationType;
+
+@Builder
+@Getter
+public class GetNotificationListDTO {
+    private String key;
+    private NotificationType type;
+    private String productNumber;
+    private String productName;
+    private int remainingQuantity;
+    private int changedAmount;
+
+    public static Slice<GetNotificationListDTO> fromSlice(Slice<Notification> notificationList) {
+        return notificationList.map(notification -> GetNotificationListDTO.builder()
+            .key(notification.getKey())
+            .type(notification.getType())
+            .productNumber(notification.getProductNumber())
+            .productName(notification.getProductName())
+            .remainingQuantity(notification.getRemainingQuantity())
+            .changedAmount(notification.getChangedAmount())
+            .build()
+        );
+    }
+}

--- a/common/src/main/java/site/moasis/common/dto/GetNotificationListDTO.java
+++ b/common/src/main/java/site/moasis/common/dto/GetNotificationListDTO.java
@@ -3,28 +3,22 @@ package site.moasis.common.dto;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Slice;
-import site.moasis.common.entity.Notification;
 import site.moasis.common.enums.NotificationType;
 
 @Builder
 @Getter
 public class GetNotificationListDTO {
-    private String key;
-    private NotificationType type;
-    private String productNumber;
-    private String productName;
-    private int remainingQuantity;
-    private int changedAmount;
+    private Slice<GetNotificationListInnerDTO> slice;
 
-    public static Slice<GetNotificationListDTO> fromSlice(Slice<Notification> notificationList) {
-        return notificationList.map(notification -> GetNotificationListDTO.builder()
-            .key(notification.getKey())
-            .type(notification.getType())
-            .productNumber(notification.getProductNumber())
-            .productName(notification.getProductName())
-            .remainingQuantity(notification.getRemainingQuantity())
-            .changedAmount(notification.getChangedAmount())
-            .build()
-        );
+    @Builder
+    @Getter
+    public static class GetNotificationListInnerDTO {
+        private String key;
+        private NotificationType type;
+        private String productNumber;
+        private String productName;
+        private int remainingQuantity;
+        private int changedAmount;
+        private boolean isRead;
     }
 }

--- a/common/src/main/java/site/moasis/common/dto/SetNotificationListAsReadRequestDTO.java
+++ b/common/src/main/java/site/moasis/common/dto/SetNotificationListAsReadRequestDTO.java
@@ -1,0 +1,12 @@
+package site.moasis.common.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class SetNotificationListAsReadRequestDTO {
+    @NotNull(message = "notificationKeys은 null일 수 없습니다.")
+    @Size(min = 1, message = "notificationKeys은 최소한 하나의 요소를 가져야 합니다.")
+    private String[] notificationKeys;
+}

--- a/common/src/main/java/site/moasis/common/entity/Notification.java
+++ b/common/src/main/java/site/moasis/common/entity/Notification.java
@@ -1,0 +1,35 @@
+package site.moasis.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.moasis.common.enums.NotificationType;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(indexes = {@Index(name = "notification_key_index", columnList = "notification_read_status_key")})
+public class Notification extends BaseEntity {
+    @Column(unique = true)
+    private String key;
+
+    private String productNumber;
+
+    private String productName;
+
+    private NotificationType type;
+
+    private int remainingQuantity = 0;
+
+    private int changedAmount = 0;
+
+    @Column(name = "notification_read_status_key", unique = true)
+    private String notificationReadStatusKey;
+}

--- a/common/src/main/java/site/moasis/common/entity/Notification.java
+++ b/common/src/main/java/site/moasis/common/entity/Notification.java
@@ -2,8 +2,6 @@ package site.moasis.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Index;
-import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +13,6 @@ import site.moasis.common.enums.NotificationType;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(indexes = {@Index(name = "notification_key_index", columnList = "notification_read_status_key")})
 public class Notification extends BaseEntity {
     @Column(unique = true)
     private String key;
@@ -29,7 +26,4 @@ public class Notification extends BaseEntity {
     private int remainingQuantity = 0;
 
     private int changedAmount = 0;
-
-    @Column(name = "notification_read_status_key", unique = true)
-    private String notificationReadStatusKey;
 }

--- a/common/src/main/java/site/moasis/common/enums/NotificationType.java
+++ b/common/src/main/java/site/moasis/common/enums/NotificationType.java
@@ -1,0 +1,5 @@
+package site.moasis.common.enums;
+
+public enum NotificationType {
+    CREATE, UPDATE, DELETE
+}

--- a/common/src/main/java/site/moasis/common/repository/NotificationRepository.java
+++ b/common/src/main/java/site/moasis/common/repository/NotificationRepository.java
@@ -1,0 +1,14 @@
+package site.moasis.common.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import site.moasis.common.entity.Notification;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    Notification findByKey(String key);
+
+    Slice<Notification> findAllByOrderByCreatedAtDesc(Pageable pageable);
+}

--- a/common/src/main/resources/application-redis.yaml
+++ b/common/src/main/resources/application-redis.yaml
@@ -1,0 +1,4 @@
+spring:
+  redis:
+    host: localhost
+    port: 6379


### PR DESCRIPTION
## #️⃣ PR과 관련된 내용(Notion Ticket)

## 📝 작업 내용
- GET /notifications method 구현
- POST /notifiactions method 구현으로 알림 읽음 처리 구현
- production 생성 / 업데이트 / 삭제에 따라 알람 생성
- notifitacion.http 생성

## 💬 리뷰 요구사항
- GET method 부분에 어차피 total product 사이즈를 알아야 한다면 Page 방식을 사용하면 좋지 않은지
- notification surrogate key인 "key"를 사용한 것에 대해 적합한지

## 체크리스트
- [x] 빌드 실패 및 코드 오류가 없는지
- [x] 미리 정의 된 린트 룰에 위배되지 않는지
- [x] 로컬에서 개발자 검증을 완료하였는지
