### PR TITLE
build/jib settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### local yaml files ###
 resources/application-local.yaml
+
+### jib container version info ###
+.env

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,16 @@ postgres:
 	docker run --name moasis -p 5432:5432 -e POSTGRES_USER=root -e POSTGRES_PASSWORD=secret -e POSTGRES_DB=moasis -d postgres:14-alpine
 redis:
 	docker run --name moasis-redis -p 6379:6379 -d redis:alpine
+	docker run --name moasis -p 5433:5432 -e POSTGRES_USER=root -e POSTGRES_PASSWORD=secret -e POSTGRES_DB=moasis -d postgres:14-alpine
+
+# 루트 프로젝트의 build.gradle 에서 아래의 버전 변경 후 실행
+# allprojects {
+#     version = '0.0.<VERSION>'
+# }
+build:
+	./gradlew :api:jibDockerBuild
+	./gradlew :image-processor:jibDockerBuild
+	./gradlew setDockerComposeEnv
+	docker-compose --env-file .env up
+
+.PHONY: postgres build

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -9,11 +9,17 @@ ext {
 }
 
 group = 'site.moasis'
-version = '0.0.1-SNAPSHOT'
+version = rootProject.version
 
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+jib {
+    container {
+        ports = ['8080']
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,14 @@ plugins {
     id 'org.sonarqube' version '5.0.0.4638'
     id 'org.springframework.boot' version '3.3.0'
     id 'io.spring.dependency-management' version '1.1.5'
+    id 'com.google.cloud.tools.jib' version '3.1.4' apply false
 }
 
 group = 'site.moasis'
-version = '0.0.1-SNAPSHOT'
+
+allprojects {
+    version = '0.0.1'
+}
 
 java {
     toolchain {
@@ -24,6 +28,56 @@ configurations {
         extendsFrom annotationProcessor
     }
 }
+
+subprojects {
+    apply plugin: 'java'
+    apply plugin: 'com.google.cloud.tools.jib'
+    version = rootProject.version
+    jib {
+        from {
+            image = 'openjdk:17-slim'
+        }
+        to {
+            image = "moasis/${project.name}:${version}"
+        }
+        container {
+            ports = ['8080']
+            files {
+                path '/app/resources'
+                from 'src/main/resources'
+                include 'application*.yaml'
+            }
+            jvmFlags = [
+                    '-Dspring.config.location=classpath:/application.yaml'
+            ]
+        }
+    }
+}
+
+task writeVersionToEnv {
+    doLast {
+        def envFile = file('.env')
+        envFile.text = "VERSION=${version}\n"
+    }
+}
+
+allprojects {
+    afterEvaluate {
+        // Ensure the task runs before jib tasks
+        tasks.withType(com.google.cloud.tools.jib.gradle.JibTask) {
+            dependsOn writeVersionToEnv
+        }
+    }
+}
+
+task setDockerComposeEnv {
+    doLast {
+        def version = project.version
+        file('.env').text = "VERSION=${version}"
+    }
+}
+
+build.dependsOn setDockerComposeEnv
 
 repositories {
     mavenCentral()

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -2,10 +2,11 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.0'
     id 'io.spring.dependency-management' version '1.1.5'
+    id 'com.google.cloud.tools.jib' version '3.1.4'
 }
 
 group = 'site.moasis'
-version = '0.0.1-SNAPSHOT'
+version = rootProject.version
 
 java {
     toolchain {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services:
+  moasis-api:
+    image: moasis/moasis-api:${VERSION}
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://moasis:5432/moasis
+      - SPRING_DATASOURCE_USERNAME=root
+      - SPRING_DATASOURCE_PASSWORD=secret
+      - SPRING_JPA_HIBERNATE_DDL_AUTO=create-drop
+    depends_on:
+      - moasis
+
+  moasis-image:
+    image: moasis/moasis-image:${VERSION}
+    ports:
+      - "8181:8181"
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://moasis:5432/moasis
+      - SPRING_DATASOURCE_USERNAME=root
+      - SPRING_DATASOURCE_PASSWORD=secret
+      - SPRING_JPA_HIBERNATE_DDL_AUTO=create-drop
+      - SPRING_JPA_DATABASE_PLATFORM=org.hibernate.dialect.PostgreSQLDialect
+    depends_on:
+      - moasis
+
+  moasis:
+    image: postgres:14-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: moasis
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: secret

--- a/image-processor/build.gradle
+++ b/image-processor/build.gradle
@@ -5,11 +5,17 @@ plugins {
 }
 
 group = 'site.moasis'
-version = '0.0.1-SNAPSHOT'
+version = rootProject.version
 
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+jib {
+    container {
+        ports = ['8181']
     }
 }
 


### PR DESCRIPTION
## #️⃣ PR과 관련된 내용(Notion Ticket)
- jib and image version settings: build.gradle에서의 jib 설정, 버전관리, 설정파일 주입
- execute settings: docker-compose정의, jib로 이미지를 빌드하고 실행하는 make 스크립트 설정
- modified .gitignore: gradle과 docker-compose간의 env 교환을 위해 .env 파일을 작업중 생성. 따라서 해당 파일 ignore

## 📝 작업 내용
- jib 빌드 설정
- docker-compose로의 환경변수 주입, make build
- 루트 프로젝트의 allprojects.version을 변경하여 버전 관리

## 💬 리뷰 요구사항
- 테스트 환경인 5433:5432로 postgres 컨테이너를 포트포워딩 하려 했으나, 해당 부분에서 jdbc url에 연결하지 못하는 문제 발생. 확인 필요
- 따라서 현재 0.0.0.0:5432로 실행중인 프로세스가 존재한다면 종료 후 make build 필요

## 체크리스트
- [x] 빌드 실패 및 코드 오류가 없는지
- [x] 미리 정의 된 린트 룰에 위배되지 않는지
- [x] 로컬에서 개발자 검증을 완료하였는지
